### PR TITLE
Fix polymorphic association for replicator in Rails 4+

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -77,10 +77,10 @@ module Replicate
         options = reflection.options
         if options[:polymorphic]
           reference_class =
-            if ::ActiveRecord::VERSION::MAJOR == 3 && ::ActiveRecord::VERSION::MINOR > 0
-              attributes[reflection.foreign_type]
-            else
+            if attributes[options[:foreign_type]]
               attributes[options[:foreign_type]]
+            else
+              attributes[reflection.foreign_type]
             end
           return if reference_class.nil?
 


### PR DESCRIPTION
FYI: I forked this because I know I'm going to need to do more work between Rails 4-5 and it doesn't appear that rtomayko is accepting pull requests anymore. 

---

This conditional does not need to depend on the Rails version. We can
simply check if the options hash on reflection contains a
`foreign_type`. If it doesn't we can assume that the `foreign_type` can
be found on the reflection itself (Rails hasn't changed since Rails 3 in
that regard.)

Now for the story because I spent so much time on this it needs to be
told:

During a Rails 3.2 to Rails 4 upgrade we had a failing test saying a
uniqueness constraint was being violated. Comparing the output from 3.2
to 4 I noticed that the ID of the item being inserted into the database
wasn't being incremented properly.

After a ton of digging I found that was because when the loader would
read the attributes the `translate_ids` methods did have the required
Array of the IDs for the polymorphic association that it was loading.

This led me to track attributes all the way back to the dumper. I knew
at the point we called `listen` in the Replicator that the attributes
were already incorrect.

Using byebug I traced the calls back to the Active Record handler and
noticed that for the polymorphic type we were not filling in the array
correctly `:record_id => [:id, "PolymorphicRecord", 123]`. We were never
getting in that part of the code so that led me to the section here
where we decide what the foreign type was.

It's clear to me that this code was originally written for Rails 3.2 and
below since `foreign_type` hasn't been on options since then. We know
that Rails 4 and 5 do not change this but I don't think using version
numbers is a good way to handle this. We can simply check if the options
hash contains a foreign type and if not ask the reflection for it.

cc/ @vmg @tenderlove 