### PR TITLE
yield only if block is given

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -307,10 +307,10 @@ module Replicate
           def instance.run_callbacks(*args); yield if block_given?; end
 
           # AR 3.0.x
-          def instance._run_save_callbacks(*args); yield; end
-          def instance._run_create_callbacks(*args); yield; end
-          def instance._run_update_callbacks(*args); yield; end
-          def instance._run_commit_callbacks(*args); yield; end
+          def instance._run_save_callbacks(*args); yield if block_given?; end
+          def instance._run_create_callbacks(*args); yield if block_given?; end
+          def instance._run_update_callbacks(*args); yield if block_given?; end
+          def instance._run_commit_callbacks(*args); yield if block_given?; end
         else
           # AR 2.x
           def instance.callback(*args)


### PR DESCRIPTION
These functions may be called without a block causing a LocalJumpError. Specifically in Rails 4.2 `_run_commit_callbacks` is called without a block.

/cc @eileencodes 