### PR TITLE
Skip attribute if it's in omitted attributes

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -283,7 +283,7 @@ module Replicate
       def create_or_update_replicant(instance, attributes)
         # write replicated attributes to the instance
         attributes.each do |key, value|
-          next if key == primary_key and not replicate_id
+          next if skip_attribute?(instance.class, key)
           instance.send :write_attribute, key, value
         end
 
@@ -296,6 +296,10 @@ module Replicate
         end
 
         [instance.id, instance]
+      end
+
+      def skip_attribute?(klass, key) # :nodoc:
+        (key == primary_key && !replicate_id) || klass.replicate_omit_attributes.include?(key.to_sym)
       end
 
       # Disable all callbacks on an ActiveRecord::Base instance. Only the


### PR DESCRIPTION
There may be times when you want to use an existing script that has
attributes that should be ignored on the next dump. For example you are
no longer using a column in a table but haven't been able to drop it yet
replicate will still dump that column until it no longer exists. The
loader may not want to use this column. This is especially useful for
Rails 4.2 where you cannot write virtual attributes or attributes that
no longer exist. This way we can ignore the columns on load the same way
they're ignored on dump.

cc/ @github/rails-upgrades 