### PR TITLE
Remove query cache override

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -365,24 +365,6 @@ module Replicate
       end
     end
 
-    # Backport connection.enable_query_cache! for Rails 2.x
-    require 'active_record/connection_adapters/abstract/query_cache'
-    query_cache = ::ActiveRecord::ConnectionAdapters::QueryCache
-    if !query_cache.methods.any? { |m| m.to_sym == :enable_query_cache! }
-      query_cache.module_eval do
-        attr_writer :query_cache, :query_cache_enabled
-
-        def enable_query_cache!
-          @query_cache ||= {}
-          @query_cache_enabled = true
-        end
-
-        def disable_query_cache!
-          @query_cache_enabled = false
-        end
-      end
-    end
-
     # Load active record and install the extension methods.
     ::ActiveRecord::Base.send :include, InstanceMethods
     ::ActiveRecord::Base.send :extend,  ClassMethods


### PR DESCRIPTION
Don't override Rails query cache. This was added for Rails 2, but we're
well beyond that now and this is overriding the methods incorrectly for
Rails 5.2